### PR TITLE
Update main.go

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -71,6 +71,7 @@ func main() {
 				logs.Error("listener %s serve fail: %v", listenerConfig.ID, err)
 			}
 		}()
+		go listener.listenForCloseSignal()
 		listenerMgr.AddListener(listenerConfig.ID, listener)
 		clientIDs = append(clientIDs, listenerConfig.ClientID)
 	}


### PR DESCRIPTION
The Close method that complements the Listener type has no code to capture the close signal.